### PR TITLE
set bbox_inches = 'tight' in savefig() to avoid cropping

### DIFF
--- a/optimizerapi/optimizer.py
+++ b/optimizerapi/optimizer.py
@@ -165,7 +165,7 @@ def addPlot(result, id="generic", close=True, debug=False):
         relative to current working directory. (default is False)
     """
     pic_IObytes = io.BytesIO()
-    plt.savefig(pic_IObytes,  format='png')
+    plt.savefig(pic_IObytes,  format='png', bbox_inches = 'tight')
     pic_IObytes.seek(0)
     pic_hash = base64.b64encode(pic_IObytes.read())
     result.append({


### PR DESCRIPTION
A minor change to how figures are saved. Using bbox_inches = 'tight' seems to fix issues with information being cropped out of plots (see issue #19). However only tested with a couple of examples.