### PR TITLE
Add CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project expose a REST based API for [ProcessOptimizer](https://github.com/n
 
 # How do I get started
 
-If you have Docker installed the API can be started locally by running the script `build-and-run.sh`
+If you have Docker installed the API can be started locally, in development mode, by running the script `build-and-run.sh`
 
 Alternatively the project can be build and run with the following commands:
 
@@ -61,6 +61,29 @@ worker threads using the following commands:
     python -m optimizerapi.worker
 
 The Redis server can be controlled through the environment variable `REDIS_URL` which defaults to `redis://localhost:6379`
+
+# Use [CORS](https://flask-cors.readthedocs.io/en/latest/index.html)
+
+The API server supports exposing its functionality to other origins than its own.
+To start the API server in "CORS mode" set the environment variable `CORS_ORIGIN=.*` and start the server.
+This opens up the API server to any origin that might want to request it.
+
+    CORS_ORIGIN=.* python -m optimizerapi.server
+
+You might want to lock the origin down a little tighter. The `CORS_ORIGIN` variable
+is a regular expression and can be used to lock the server to a single host or multiple.
+
+A single specific origin:
+
+    CORS_ORIGIN="https://prod.brownie.projects.alexandra.dk" python -m optimizerapi.server
+
+All subdomains hosted by alexandra.dk:
+
+    CORS_ORIGIN="https://.*.alexandra.dk" python -m optimizerapi.server
+
+Two specific origins:
+
+    CORS_ORIGIN="(https://prod.brownie.projects.alexandra.dk|https://prod.cake.projects.alexandra.dk)" python -m optimizerapi.server
 
 # Adding or updating dependencies
 

--- a/build-and-run.sh
+++ b/build-and-run.sh
@@ -1,3 +1,9 @@
 #!/bin/sh
 
-docker build -t process-optimizer-api . && docker run --rm -it -p 9090:9090 process-optimizer-api
+docker build -t process-optimizer-api . && \
+docker run \
+--rm \
+-it \
+-p 9090:9090 \
+-e FLASK_ENV="development" \
+process-optimizer-api

--- a/optimizerapi/server.py
+++ b/optimizerapi/server.py
@@ -2,9 +2,11 @@
 Main server
 """
 import os
+import re
 import connexion
 from waitress import serve
 from .securepickle import get_crypto
+from flask_cors import CORS
 
 if __name__ == '__main__':
     # Initialize crypto
@@ -13,8 +15,44 @@ if __name__ == '__main__':
         __name__, port=9090, specification_dir='./openapi/')
     app.add_api('specification.yml', arguments={
                 'title': 'Hello World Example'})
-    if os.getenv("FLASK_ENV", "development") == "development":
-        os.environ["FLASK_ENV"] = "development"
+
+    DEVELOPMENT = "development"
+    flask_env = os.getenv("FLASK_ENV", DEVELOPMENT)
+    development = flask_env == DEVELOPMENT
+    if development:
+        os.environ["FLASK_ENV"] = DEVELOPMENT
+
+    # It should be easy to get started developing locally which is the reason
+    # why we allow for all origins in development mode.
+    ALLOW_ALL_ORIGINS = ".*"
+    cors_origin = os.getenv(
+        "CORS_ORIGIN", ALLOW_ALL_ORIGINS if development else None)
+
+    # By default we do not want to enable CORS. That should be a conscious
+    # descision from the host of the API server. This way we do not expose any
+    # additional vulnerabilities by default.
+    if cors_origin:
+        try:
+            # https://connexion.readthedocs.io/en/latest/cookbook.html?highlight=cors#cors-support
+            # https://flask-cors.readthedocs.io/en/latest/configuration.html#default-values
+            CORS(
+                app.app,
+                # OPTIONS is required for the preflight request when doing CORS.
+                # The HEAD, GET and POST is functionality we want exposed.
+                methods=["HEAD", "OPTIONS", "GET", "POST"],
+                # re.compile allows for quite complex origin definitions through
+                # our environment variable. The List would be cumbersome to
+                # parse and the simple string is not enough functionality for
+                # what we want to support.
+                origins=re.compile(cors_origin)
+            )
+            print("CORS: " + cors_origin)
+        except re.error:
+            print("CORS: failed - the regex might be malformed.")
+    else:
+        print("CORS: disabled")
+
+    if development:
         app.run()
     else:
         serve(app, listen='*:9090')

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -13,6 +13,7 @@ deap==1.3.1
 Deprecated==1.2.13
 docopt==0.6.2
 Flask==1.1.2
+Flask-Cors==3.0.10
 idna==2.10
 inflection==0.5.1
 iniconfig==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 connexion==2.7.0
 connexion[swagger-ui]
 Flask==1.1.2
+Flask-Cors==3.0.10
 ProcessOptimizer==0.7.3
 json-tricks==3.15.5
 cryptography==3.4.7


### PR DESCRIPTION
This is trying to add the flask-cors package.

~~The default right now is "*" which might not be the best due to it's lenience. But what might be a safe, sane default? Is the configurable `origins` best as an env variable or is there a better way of configuring the project at run time?~~

When in `development` mode the CORS origin is set to allow from all origins. `production` does not even allow for CORS if the `CORS_ORIGIN` environment variable isn't set. This should allow for a deployment of the code base without having to make any changes to anyone's current deployment scripts and procedures.

The configuration of CORS is described in the README.