### PR TITLE
Configurable auth URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /tmp
 version.txt
 .env
+
+# This file is rendered by the scripts/configure_api.py
+optimizerapi/openapi/specification.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,24 @@ WORKDIR /code
 ENV VERSION=${GITHUB_REF_NAME}
 ENV SHA=${GITHUB_SHA}
 
-# add non-root user
-RUN addgroup --system user && adduser --system --no-create-home --group user
-RUN chown -R user:user /code && chmod -R 755 /code
-RUN mkdir -p /code/mapplotlib
+# Add entrypoint scripts
+COPY scripts/configure_api.py /scripts/configure_api.py
+COPY scripts/entrypoint.sh /scripts/entrypoint.sh
+COPY templates/ /code/templates
 
-USER user
+## add non-root user
+## This currently causes the entrypoint script that configures the openapi/specification.yml file with the following traceback
+##   Traceback (most recent call last):
+##     File "/code/../scripts/configure_api.py", line 36, in <module>
+##       write_yaml_config(config_dest=destination, conf=conf)
+##     File "/code/../scripts/configure_api.py", line 24, in write_yaml_config
+##       with open(config_dest, "w") as f:
+##   PermissionError: [Errno 13] Permission denied: 'optimizerapi/openapi/specification.yml'
+# RUN addgroup --system user && adduser --system --no-create-home --group user
+# RUN chown -R user:user /code && chmod -R 755 /code
+# RUN mkdir -p /code/mapplotlib
+
+# USER user
 
 COPY --from=builder /requirements-fixed.txt /code/requirements-freeze.txt
 #COPY version.txt /code
@@ -40,4 +52,5 @@ ENV MPLCONFIGDIR=/tmp/mapplotlib
 ENV PATH=/opt/venv/bin:${PATH}
 VOLUME /code/matplotlib
 
+ENTRYPOINT [ "/scripts/entrypoint.sh" ]
 CMD [ "python", "-m", "optimizerapi.server" ]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ or use pytest-watch for continuously running tests
 
 Run server once and extract a fresh encryption key from the logs.
 
+    ## optional add auth url
+    # export PO_AUTH_URL="http://authurl"
+
+    python scripts/configure_api.py
     python -m optimizerapi.server
 
 or using docker
@@ -44,12 +48,19 @@ or using docker
 # Running in production
 
 Running using python
-
-    FLASK_ENV=production PICKLE_KEY=<key from previous step> python -m optimizerapi.server
+    
+    ## optional add auth url
+    # export PO_AUTH_URL="http://authurl"
+    python scripts/configure_api.py
+    FLASK_ENV=production PICKLE_KEY=<key from previous step>  python -m optimizerapi.server
 
 or use docker
 
-    docker run -d --name process-optimizer-api --env PICKLE_KEY=<key from previous step> -p 9090:9090 process-optimizer-api:latest
+    docker run -d --name process-optimizer-api --env PICKLE_KEY=<key from previous step> --env PO_AUTH_URL="http://authurl" -p 9090:9090 process-optimizer-api:latest
+
+or use docker compose
+
+    docker compose up --build
 
 # Use job queue
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,10 +31,10 @@ services:
     volumes:
       - redis-data:/data
   ui:
-    image: ghcr.io/boostv/process-optimizer-frontend/server:main
+    image: ghcr.io/boostv/process-optimizer-frontend:1.6.3
     restart: unless-stopped
     ports:
-      - 3000:3000
+      - 3000:80
     environment:
       - API_SERVER=http://api:9090/v1.0
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,8 @@ services:
       - redis
     build:
       context: .
-    scale: 10
+    deploy:
+      replicas: 1
     command: python -m optimizerapi.worker
     environment:
       - REDIS_URL=redis://redis:6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,9 @@ services:
     environment:
       - USE_WORKER=true
       - REDIS_URL=redis://redis:6379
+      - CORS_ORIGIN=http://localhost:3000
+      ## uncomment to enable authentication in the API specification
+      #- PO_AUTH_URL=https://keycloak.browniebee.projects.alexandra.dk/realms/brownie-bee-dev/protocol/openid-connect/auth
   worker:
     restart: unless-stopped
     depends_on: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     build:
       context: .
     deploy:
-      replicas: 1
+      replicas: 10
     command: python -m optimizerapi.worker
     environment:
       - REDIS_URL=redis://redis:6379

--- a/optimizerapi/openapi/readme.md
+++ b/optimizerapi/openapi/readme.md
@@ -1,0 +1,5 @@
+# openapi
+
+The openapi configuration file is jinja templated in the templates folder. 
+
+The script `scripts/configure_api.py` will write the specification.yml to this directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ jsonschema==4.15.0
 cryptography==3.4.7
 waitress==2.1.2
 rq==1.10.0
+jinja2==3.1.2

--- a/scripts/configure_api.py
+++ b/scripts/configure_api.py
@@ -1,0 +1,37 @@
+import os
+import pathlib
+import yaml
+
+from jinja2 import Environment
+
+template = Environment()
+
+
+def parse_yaml_config(config_path: pathlib.Path) -> dict:
+    """
+    load a yaml file, inject environment variables
+    into it and return it as a dict
+    """
+
+    with open(config_path, encoding="utf-8", mode="r") as f:
+        parsed_config = template.from_string(f.read()).render(**os.environ)
+        return yaml.safe_load(parsed_config)
+
+
+def write_yaml_config(config_dest: pathlib.Path, conf: dict) -> None:
+    """write a jinja2 template to disk"""
+
+    with open(config_dest, "w") as f:
+        yaml.dump(conf, f, indent=2)
+
+
+if __name__ == "__main__":
+    # Open template
+    source = pathlib.Path("templates/specification.yml.j2")
+    conf = parse_yaml_config(config_path=source)
+    print(f"loaded {source}", flush=True)
+
+    # Write results
+    destination = pathlib.Path("optimizerapi/openapi/specification.yml")
+    write_yaml_config(config_dest=destination, conf=conf)
+    print(f"wrote {destination}", flush=True)

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+python ../scripts/configure_api.py
+# ensure docker user has access to api specification 
+#chown user:user optimizerapi/openapi/specification.yml
+exec "$@"

--- a/templates/specification.yml.j2
+++ b/templates/specification.yml.j2
@@ -9,9 +9,11 @@ servers:
 paths:
   /optimizer:
     post:
+      {% if PO_AUTH_URL %}
       security:
         - oauth2: []
         - apikey: []
+      {% endif %}
       description: Run optimizer with the specified parameters
       operationId: optimizerapi.optimizer.run
       responses:
@@ -124,6 +126,7 @@ paths:
                   }
 
 components:
+  {% if PO_AUTH_URL %}
   securitySchemes:
     apikey:
       x-apikeyInfoFunc: optimizerapi.auth.apikey_handler
@@ -135,8 +138,10 @@ components:
       x-tokenInfoFunc: optimizerapi.auth.token_info
       flows:
         implicit:
-          authorizationUrl: https://keycloak.browniebee.projects.alexandra.dk/realms/brownie-bee-dev/protocol/openid-connect/auth
+          # authorizationUrl: https://keycloak.browniebee.projects.alexandra.dk/realms/brownie-bee-dev/protocol/openid-connect/auth
+          authorizationUrl: {{ PO_AUTH_URL }}
           scopes: {}
+  {% endif %}
   schemas:
     experiment:
       title: An experiment definition


### PR DESCRIPTION
## Change
This PR adds the ability to configure the openapi specification yaml using jinja2 templating to add the auth URL as an option.

## Reason
Without this it is unfortunately not possible to run on a local deployment which would be nice.

## Caveat
Note that this removes the user:user in the docker file as I could not figure out how to run the templating script as the user without running into `PermissionError: [Errno 13] Permission denied: 'optimizerapi/openapi/specification.yml'`

#77 