### PR TITLE
add health check path

### DIFF
--- a/optimizerapi/health.py
+++ b/optimizerapi/health.py
@@ -1,0 +1,2 @@
+def check() -> str:
+    return "OK"

--- a/optimizerapi/openapi/specification.yml
+++ b/optimizerapi/openapi/specification.yml
@@ -122,6 +122,13 @@ paths:
                           ],
                       },
                   }
+  /health:
+    get:
+      description: Health check endpoint
+      operationId: optimizerapi.health.check
+      responses:
+        "200":
+          description: Service is reachable
 
 components:
   securitySchemes:


### PR DESCRIPTION
This PR adds a `v1.0/health` path to the API. This enables monitoring the service _liveness_ with minimal resource usage.